### PR TITLE
fix: separate the version command using zsh

### DIFF
--- a/scripts/install-testnet-packages.sh
+++ b/scripts/install-testnet-packages.sh
@@ -789,8 +789,6 @@ else
     exit 1
 fi
 
-
-
 # Function to check if a command exists and its version if necessary
 function check_command_version {
     CMD=$1
@@ -798,7 +796,14 @@ function check_command_version {
     VERSION_CMD=$3
 
     if command -v "$CMD" &> /dev/null; then
-        CURRENT_VERSION=$($VERSION_CMD 2>&1 | head -n 1)
+
+        # If zsh, enable word splitting option locally.
+        if [[ "$OS_TYPE" == "darwin" ]]; then
+            setopt localoptions sh_word_split
+        fi
+
+        CURRENT_VERSION=$(eval $VERSION_CMD 2>&1 | head -n 1)
+
         if [[ -z "$EXPECTED_VERSION" ]]; then
             if [[ "$CMD" == "forge" || "$CMD" == "cast" || "$CMD" == "anvil" ]]; then
                 echo "✅ foundry - $CMD is installed. Current version: $CURRENT_VERSION"
@@ -818,7 +823,6 @@ function check_command_version {
         fi
     fi
 }
-
 
 if [[ "$SUCCESS" == "true" ]]; then
     echo "All required tools are installed and ready to use!"


### PR DESCRIPTION
I fixed the 'command not found' issue running install-testnet-dependencies.sh to separate the version command on MacOS.