### PR TITLE
Fixed unexpected prompt input result on ScanBool

### DIFF
--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -22,10 +22,14 @@ func ScanBool(defaultResponse bool) (bool, error) {
 		return false, err
 	}
 
-	if strings.ToLower(response) == "y" {
+	switch strings.ToLower(strings.TrimSpace(response)) {
+	case "y":
 		return true, nil
+	case "n":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid input: must be 'y' or 'n'")
 	}
-	return defaultResponse, nil
 }
 
 func ScanString() (string, error) {


### PR DESCRIPTION
I updated `ScanBool` function to avoid unexpected prompt input results. When I put the "n" in the prompt, the return value of `scanBool(true)` is true while `trh-sdk update`

### Fixed
```bash
Do you want to update the L1 RPC? (Y/n): n
Do you want to update the L1 Beacon RPC? (Y/n): n
Do you want to update the network? (Y/n): n
Skip to update the network
```