### PR TITLE
Feat: setup safe wallet before registering DAO candidate

### DIFF
--- a/commands/verify-register-candidate.go
+++ b/commands/verify-register-candidate.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/tokamak-network/trh-sdk/pkg/constants"
 	"github.com/tokamak-network/trh-sdk/pkg/stacks/thanos"
@@ -13,6 +14,11 @@ import (
 func ActionVerifyRegisterCandidates() cli.ActionFunc {
 	return func(ctx context.Context, cmd *cli.Command) error {
 		var err error
+		// Retrieve the current working directory
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get current working directory: %v", err)
+		}
 		config, err := utils.ReadConfigFromJSONFile()
 		if err != nil || config == nil {
 			return fmt.Errorf("Check if contracts deployed on L1, use `deploy-contracts` command for that: %v", err)
@@ -21,7 +27,7 @@ func ActionVerifyRegisterCandidates() cli.ActionFunc {
 		switch config.Stack {
 		case constants.ThanosStack:
 			thanosStack := thanos.NewThanosStack(config.Network, config.Stack)
-			err = thanosStack.VerifyRegisterCandidates(ctx, config)
+			err = thanosStack.VerifyRegisterCandidates(ctx, config, cwd)
 			return err
 		default:
 			return fmt.Errorf("unsupported stack: %s", config.Stack)

--- a/pkg/stacks/thanos/register_candidate.go
+++ b/pkg/stacks/thanos/register_candidate.go
@@ -249,15 +249,15 @@ func (t *ThanosStack) VerifyRegisterCandidates(ctx context.Context, config *type
 	var err error
 	registerCandidate, err := t.inputRegisterCandidate()
 	if err != nil {
-		return err
+		return fmt.Errorf("❌ failed to get register candidate input: %w", err)
 	}
 	err = t.setupSafeWallet(config, cwd)
 	if err != nil {
-		return err
+		return fmt.Errorf("❌ failed to set up Safe Wallet: %w", err)
 	}
 	err = t.verifyRegisterCandidates(ctx, config, registerCandidate)
 	if err != nil {
-		return err
+		return fmt.Errorf("❌ candidate verification failed: %w", err)
 	}
 	fmt.Println("✅ Candidate registration completed successfully!")
 	return nil
@@ -285,7 +285,7 @@ func (t *ThanosStack) setupSafeWallet(config *types.Config, cwd string) error {
 	sdkPath := filepath.Join(cwd, "tokamak-thanos", "packages", "tokamak", "sdk")
 	cmdStr := fmt.Sprintf("cd %s && L1_URL=%s PRIVATE_KEY=%s SAFE_WALLET_ADDRESS=%s npx hardhat set-safe-wallet", sdkPath, config.L1RPCURL, config.AdminPrivateKey, safeWalletAddress)
 	if err := utils.ExecuteCommandStream("bash", "-c", cmdStr); err != nil {
-		fmt.Print("\r❌ failed to setup the Safe wallet!\n")
+		fmt.Print("\rfailed to setup the Safe wallet!\n")
 		return err
 	}
 

--- a/pkg/stacks/thanos/thanos_stack.go
+++ b/pkg/stacks/thanos/thanos_stack.go
@@ -294,6 +294,10 @@ func (t *ThanosStack) DeployContracts(ctx context.Context, deployConfig *types.C
 
 	// If --no-candidate flag is NOT provided, register the candidate
 	if t.registerCandidate {
+		fmt.Println("Setting up the safe wallet...")
+		if err := t.setupSafeWallet(deployConfig, cwd); err != nil {
+			return err
+		}
 		fmt.Println("🔍 Verifying and registering candidate...")
 		verifyRegisterError := t.verifyRegisterCandidates(ctx, deployConfig, registerCandidate)
 		if verifyRegisterError != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->

This PR introduces a new step in the candidate registration process by setting up the safe wallet prior to registration. The following changes have been made:

* Added functionality to read the `SystemOwnerSafe` address from the deployment JSON file.
* Set a .env file with necessary environment variables: `L1_URL`, `PRIVATE_KEY`, and `SAFE_WALLET_ADDRESS`.
* Executed the Hardhat task `set-safe-wallet` to complete the safe wallet setup.

These enhancements aim to streamline the candidate registration process by ensuring the safe wallet is properly configured beforehand.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

We can test it with two cases:
1. Automatically setup the safe wallet after contract deployment on L1: If L2 operator does not put the `--no-candidate` with `deploy-contracts`, L2 will be registered as DAO candidate.
```bash
go build
mkdir testnet
cp ./trh-sdk ./testnet
./trh-sdk deploy-contracts --network testnet --stack thanos
```

2. run `verify-register-candidate` command of trh-sdk: If L2 operator wants to register DAO candidate after deployment
```bash
go build
mkdir testnet
cp ./trh-sdk ./testnet
./trh-sdk verify-register-candidate
```

The expected results are as below:
```bash
# example
Setup task...
2025-05-16T23:37:50.406+0900    Setup task...
2025-05-16T23:37:50.419+0900    Setup task...
2025-05-16T23:37:50.430+0900    Setup task...
2025-05-16T23:37:50.438+0900    Setup task...
2025-05-16T23:37:50.933+0900    L1 Chain ID: 11155111
2025-05-16T23:37:50.939+0900    Gnosis Safe Contract: 0x1C3b0031B45AC0E4cdfeCe0A8537e70fCabF06A5
2025-05-16T23:37:52.283+0900    Tx Hash for adding owner 0x0Fd5632f3b52458C31A2C3eE1F4b447001872Be9: 0x6b71ec827306a3c053082edb87a87d39f50c4fe31ff001d0be28a3d57c65ac5c
2025-05-16T23:38:05.059+0900    Safe owners after adding owner 0x0Fd5632f3b52458C31A2C3eE1F4b447001872Be9: [
2025-05-16T23:38:05.059+0900      '0x0Fd5632f3b52458C31A2C3eE1F4b447001872Be9',
2025-05-16T23:38:05.059+0900      '0xD7D57ba9F40629d48c4009a87654CDDa8A5433E9'
2025-05-16T23:38:05.059+0900    ]
2025-05-16T23:38:05.059+0900    Successfully added owner: 0x0Fd5632f3b52458C31A2C3eE1F4b447001872Be9
2025-05-16T23:38:06.111+0900    Tx Hash for adding owner 0x61dc95E5f27266b94805ED23D95B4C9553A3D049: 0x8e2f1a06d9334a11ef0ad1a2dcd1c64852f63f5d5d6969f3793618266647a443
2025-05-16T23:38:14.855+0900    Safe owners after adding owner 0x61dc95E5f27266b94805ED23D95B4C9553A3D049: [
2025-05-16T23:38:14.855+0900      '0x61dc95E5f27266b94805ED23D95B4C9553A3D049',
2025-05-16T23:38:14.855+0900      '0x0Fd5632f3b52458C31A2C3eE1F4b447001872Be9',
2025-05-16T23:38:14.855+0900      '0xD7D57ba9F40629d48c4009a87654CDDa8A5433E9'
2025-05-16T23:38:14.855+0900    ]
2025-05-16T23:38:14.855+0900    Successfully added owner: 0x61dc95E5f27266b94805ED23D95B4C9553A3D049
2025-05-16T23:38:16.035+0900    Tx Hash for changing threshold: 0x770ea3a72d59ff1ffab2bbc919fb694e89d2f3cdd3e0b4df7a66de8309eb6149
2025-05-16T23:38:28.802+0900    New threshold: 3
```
## Screenshots (if appropriate):
