### PR TITLE
chore: update docker image tag for mainnet

### DIFF
--- a/pkg/constants/docker_images.go
+++ b/pkg/constants/docker_images.go
@@ -5,5 +5,5 @@ var DockerImageTag = map[string]struct {
 	ThanosStackImageTag string
 }{
 	Testnet: {OpGethImageTag: "193382ee", ThanosStackImageTag: "56ed30e3"},
-	Mainnet: {OpGethImageTag: "c61a056f", ThanosStackImageTag: "011bec4a"},
+	Mainnet: {OpGethImageTag: "a7c74c7e", ThanosStackImageTag: "49e37d47"},
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->

Updated docker image tag for the mainnet. It is used in the infra deployment step.
* op-geth: [nightly-a7c74c7e](https://hub.docker.com/layers/tokamaknetwork/thanos-op-geth/nightly-a7c74c7e/images/sha256-323d0a313bd9bca635bd0b57bc14cc7d8395c4732e381d216cf034ffa52f427f)
* op-node: [nightly-49e37d47](https://hub.docker.com/layers/tokamaknetwork/thanos-op-node/nightly-49e37d47/images/sha256-dd61e146ba6704fc85bb5af4f0ba636e4b45d91de9436c6034a3391bf7cc9e18)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
