### PR TITLE
add `reuseDeployment` field to deploy config file

### DIFF
--- a/pkg/stacks/thanos/utils.go
+++ b/pkg/stacks/thanos/utils.go
@@ -288,6 +288,7 @@ func initDeployConfigTemplate(deployConfigInputs *DeployContractsInput, l2ChainI
 		GovernanceTokenOwner:                     "0x0000000000000000000000000000000000000333",
 		GovernanceTokenSymbol:                    "OP",
 		L2OutputOracleChallenger:                 "0x0000000000000000000000000000000000000001",
+		ReuseDeployment:                          true,
 	}
 
 	return defaultTemplate

--- a/pkg/types/deploy_config_template.go
+++ b/pkg/types/deploy_config_template.go
@@ -85,4 +85,5 @@ type DeployConfigTemplate struct {
 	PairInitCodeHash                         string   `json:"pairInitCodeHash"`
 	PoolInitCodeHash                         string   `json:"poolInitCodeHash"`
 	UniversalRouterRewardsDistributor        string   `json:"universalRouterRewardsDistributor"`
+	ReuseDeployment                          bool     `json:"reuseDeployment"`
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->

For testing TON Staking v2, I added `reuseDeployment` field to deploy config file. We need to use it for verifying implementation contracts. Please refer to this [code](https://github.com/tokamak-network/tokamak-thanos/blob/74223d1e7ed07df8d94bc969ac9dbfa8604316b3/packages/tokamak/contracts-bedrock/src/tokamak-contracts/verification/L1ContractVerification.sol#L379-L393).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Related PR: https://github.com/tokamak-network/tokamak-thanos/pull/338

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
