### PR TITLE
fix: check to ensure running docker while `destroy` command

### DIFF
--- a/pkg/stacks/thanos/thanos_stack.go
+++ b/pkg/stacks/thanos/thanos_stack.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"runtime"
 	"strings"
 	"time"
 
@@ -722,6 +723,14 @@ func (t *ThanosStack) deployNetworkToAWS(ctx context.Context) error {
 func (t *ThanosStack) Destroy(ctx context.Context) error {
 	fileName := fmt.Sprintf("logs/destroy_thanos_%s_%s_%d.log", t.stack, t.network, time.Now().Unix())
 	logging.InitLogger(fileName)
+
+	// To ensure docker execution and socket permissions
+	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+		if err := utils.EnsureDockerReady(); err != nil {
+			return fmt.Errorf("docker setup failed: %w", err)
+		}
+	}
+
 	switch t.network {
 	case constants.LocalDevnet:
 		return t.destroyDevnet()

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
 	"strings"
+	"time"
 )
 
 type DockerContainer struct {
@@ -48,4 +52,102 @@ func GetDockerContainers(ctx context.Context) ([]string, error) {
 	}
 
 	return runningContainers, nil
+}
+
+// Check if Docker is running and start it if necessary
+func EnsureDockerReady() error {
+	// Check OS
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		return nil
+	}
+
+	// Check if Docker daemon is running
+	if _, err := ExecuteCommand("docker", "info"); err == nil {
+		return nil // already running
+	}
+
+	// Start Docker
+	if err := startDocker(); err != nil {
+		return err
+	}
+
+	// Wait until Docker is ready
+	maxRetries := 30
+	if runtime.GOOS == "darwin" {
+		maxRetries = 60 // macOS Docker Desktop
+	}
+
+	for i := 0; i < maxRetries; i++ {
+		if _, err := ExecuteCommand("docker", "info"); err == nil {
+			// Docker is running, fix socket permissions if needed
+			fixDockerSocketPermissions()
+			return nil // success
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	return fmt.Errorf("docker failed to start within timeout")
+}
+
+func startDocker() error {
+	switch runtime.GOOS {
+	case "darwin":
+		// Check Docker Desktop paths
+		dockerPaths := []string{"/Applications/Docker.app", "/System/Applications/Docker.app"}
+		for _, path := range dockerPaths {
+			if _, err := os.Stat(path); err == nil {
+				// Check if already running
+				if _, err := ExecuteCommand("pgrep", "-f", "Docker Desktop"); err == nil {
+					return nil
+				}
+				_, err := ExecuteCommand("open", "-a", path)
+				return err
+			}
+		}
+
+		// Check colima
+		if _, err := ExecuteCommand("which", "colima"); err == nil {
+			_, err := ExecuteCommand("colima", "start")
+			return err
+		}
+
+		return fmt.Errorf("docker Desktop not found. Please install from https://docker.com/products/docker-desktop")
+
+	case "linux":
+		// Check systemd
+		if _, err := os.Stat("/run/systemd/system"); err == nil {
+			_, err := ExecuteCommand("sudo", "systemctl", "start", "docker")
+			return err
+		}
+
+		// Fallback for non-systemd systems
+		cmd := exec.Command("sudo", "dockerd")
+		return cmd.Start()
+
+	default:
+		return fmt.Errorf("unsupported OS: %s", runtime.GOOS)
+	}
+}
+
+// fixDockerSocketPermissions fixes Docker socket permission issues
+func fixDockerSocketPermissions() {
+	switch runtime.GOOS {
+	case "linux":
+		fixLinuxDockerPermissions()
+	}
+	// darwin: Docker Desktop in macOS is automatically managing docker socket
+}
+
+// fixLinuxDockerPermissions fixes Docker socket permissions on Linux
+func fixLinuxDockerPermissions() {
+	dockerSock := "/var/run/docker.sock"
+
+	// Check if socket exists
+	if _, err := os.Stat(dockerSock); os.IsNotExist(err) {
+		return
+	}
+
+	// Fix socket permissions (ignore errors - best effort)
+	ExecuteCommand("sudo", "chmod", "666", dockerSock)
+	ExecuteCommand("sudo", "chgrp", "docker", dockerSock)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->

Users encounter permission denied errors when destroying the Thanos Stack due to Docker socket permission issues.

* Added: `pkg/utils/docker.go` with `EnsureDockerReady()` function
* Modified: `ThanosStack.Destroy()` to call Docker readiness check
* Supports: Linux (systemd/dockerd), macOS (Docker Desktop)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/tokamak-network/trh-sdk/issues/100

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Result (Linux: Ubuntu)
```bash
ubuntu@ip-172-31-42-48:~/trh-sdk/devnet-0605$ sudo systemctl status docker
○ docker.service - Docker Application Container Engine
     Loaded: loaded (/usr/lib/systemd/system/docker.service; enabled; preset: enabled)
     Active: inactive (dead) since Thu 2025-06-05 04:30:07 UTC; 3s ago
   Duration: 1h 22min 59.871s
TriggeredBy: ● docker.socket
       Docs: https://docs.docker.com
    Process: 10094 ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock (code=exited, status=0/SUCCESS)
   Main PID: 10094 (code=exited, status=0/SUCCESS)
        CPU: 33.752s

Jun 05 04:29:57 ip-172-31-42-48 dockerd[10094]: time="2025-06-05T04:29:57.451785875Z" level=info msg="ignoring event" container=e408b471324>
Jun 05 04:29:57 ip-172-31-42-48 dockerd[10094]: time="2025-06-05T04:29:57.451825893Z" level=info msg="ignoring event" container=21c0e181d9c>
Jun 05 04:29:57 ip-172-31-42-48 dockerd[10094]: time="2025-06-05T04:29:57.482793250Z" level=info msg="ignoring event" container=a0ccacfbb83>
Jun 05 04:29:57 ip-172-31-42-48 dockerd[10094]: time="2025-06-05T04:29:57.497831368Z" level=info msg="ignoring event" container=1a91cb40861>
Jun 05 04:30:07 ip-172-31-42-48 dockerd[10094]: time="2025-06-05T04:30:07.390117867Z" level=info msg="Container failed to exit within 10s o>
Jun 05 04:30:07 ip-172-31-42-48 dockerd[10094]: time="2025-06-05T04:30:07.414968342Z" level=info msg="ignoring event" container=450542470fa>
Jun 05 04:30:07 ip-172-31-42-48 dockerd[10094]: time="2025-06-05T04:30:07.561300030Z" level=info msg="Daemon shutdown complete"
Jun 05 04:30:07 ip-172-31-42-48 systemd[1]: docker.service: Deactivated successfully.
Jun 05 04:30:07 ip-172-31-42-48 systemd[1]: Stopped docker.service - Docker Application Container Engine.
ubuntu@ip-172-31-42-48:~/trh-sdk/devnet-0605$ ./trh-sdk destroy
✅ Devnet network destroyed successfully!  
```

