### PR TITLE
Fix: Fixed staking v2.0 issue for candidate registration

### DIFF
--- a/pkg/stacks/thanos/input.go
+++ b/pkg/stacks/thanos/input.go
@@ -1021,6 +1021,7 @@ func initDeployConfigTemplate(deployConfigInputs *DeployContractsInput, l1ChainI
 		GovernanceTokenOwner:                     "0x0000000000000000000000000000000000000333",
 		GovernanceTokenSymbol:                    "OP",
 		L2OutputOracleChallenger:                 "0x0000000000000000000000000000000000000001",
+		ReuseDeployment:                          true,
 	}
 
 	return defaultTemplate


### PR DESCRIPTION
## Why did we need it?
This PR contains a fix to fetch admin address from config if deployment resumes and reuse the deployment stack implementation for contract verification

## How Has This Been Tested?
This PR is tested on local by checking both candidate registration with deploying the stack and via standalone command to register candidate - 

[Candidate Registration with deployment](https://sepolia.etherscan.io/tx/0x4596635c9bc72f3202d81c9dd1d62c49490b62afc3b0c2f811b540ecb7658bde), [Candidate Registration via Standalone Command](https://sepolia.etherscan.io/tx/0x618a1e89313bb0d50d40668cf16fd4824ff665e824e9df58a215c8508e1c83e2)

