### PR TITLE
fix: update chain name formatting to match PV naming convention

### DIFF
--- a/pkg/stacks/thanos/monitoring.go
+++ b/pkg/stacks/thanos/monitoring.go
@@ -92,6 +92,7 @@ func (t *ThanosStack) InstallMonitoring(ctx context.Context, config *MonitoringC
 func (t *ThanosStack) GetMonitoringConfig(ctx context.Context, adminPassword string) (*MonitoringConfig, error) {
 	// Use timestamped release name for monitoring
 	chainName := strings.ToLower(t.deployConfig.ChainName)
+	chainName = strings.ReplaceAll(chainName, " ", "-") // Match PV naming convention
 	timestamp := time.Now().Unix()
 	helmReleaseName := fmt.Sprintf("monitoring-%d", timestamp)
 
@@ -184,6 +185,7 @@ func (t *ThanosStack) UninstallMonitoring(ctx context.Context) error {
 	}
 
 	chainName := strings.ToLower(t.deployConfig.ChainName)
+	chainName = strings.ReplaceAll(chainName, " ", "-") // Match PV naming convention
 
 	// Clean up existing PVs and PVCs for monitoring components
 	fmt.Println("🧹 Cleaning up existing monitoring PVs and PVCs...")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR fixes chain name formatting inconsistency in monitoring functions by ensuring spaces are converted to hyphens to match the PV (PersistentVolume) naming convention used throughout the system.

## Why did we need it?
<!--- Describe your changes in detail -->

The fix ensures consistent naming across all operations, allowing monitoring plugins to correctly identify existing infrastructure resources.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
