### PR TITLE
fix: update chain name validation to allow only 10 characters or less

### DIFF
--- a/pkg/stacks/thanos/input.go
+++ b/pkg/stacks/thanos/input.go
@@ -24,7 +24,8 @@ import (
 )
 
 var (
-	chainNameRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9 ]*$`)
+	// Chain name must be 10 characters or less, and can only contain letters, numbers, and spaces
+	chainNameRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9 ]{0,9}$`)
 )
 
 type DeployContractsInput struct {
@@ -90,7 +91,7 @@ func (c *DeployInfraInput) Validate(ctx context.Context) error {
 	}
 
 	if !chainNameRegex.MatchString(c.ChainName) {
-		return errors.New("invalid chain name, chain name must contain only letters (a-z, A-Z), numbers (0-9), spaces. Special characters are not allowed")
+		return errors.New("invalid chain name, chain name must contain only letters (a-z, A-Z), numbers (0-9), spaces with 10 characters or less. Special characters are not allowed")
 	}
 
 	return nil
@@ -393,7 +394,7 @@ func InputDeployInfra() (*DeployInfraInput, error) {
 		}
 
 		if !chainNameRegex.MatchString(chainName) {
-			fmt.Println("Input must contain only letters (a-z, A-Z), numbers (0-9), spaces. Special characters are not allowed")
+			fmt.Println("Input must contain only letters (a-z, A-Z), numbers (0-9), spaces with 10 characters or less. Special characters are not allowed")
 			continue
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR limits chain name to 10 characters to prevent Kubernetes pod naming issues.

* Error case of chain name (example): "a b c d e g f h" is 15 characters. It imposes limitations due to the DNS naming specification of Kubernetes. (Maximum 63 characters) The pod name of op-batcher is generated as `a-b-c-d-e-f-g-h-1751298447-1751299608-thanos-stack-op-batcxxx78`, so the chain execution does not work properly.

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
