### PR TITLE
Fix: Transaction approval ton transfer

### DIFF
--- a/pkg/stacks/thanos/register_candidate.go
+++ b/pkg/stacks/thanos/register_candidate.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethCommon "github.com/ethereum/go-ethereum/common"
@@ -84,6 +85,37 @@ func (t *ThanosStack) checkAdminBalance(ctx context.Context, adminAddress ethCom
 			requiredAmountBigInt.String())
 	}
 	return nil
+}
+
+// waitForAllowanceWithTimeout waits for allowance to be set with a context timeout
+func waitForAllowanceWithTimeout(ctx context.Context, tonContract *abis.TON, adminAddress, l2ManagerAddress ethCommon.Address, requiredAmount *big.Int, timeout time.Duration) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	fmt.Printf("Waiting for allowance to propagate (timeout: %v)...\n", timeout)
+
+	for {
+		select {
+		case <-timeoutCtx.Done():
+			return fmt.Errorf("timeout waiting for allowance propagation after %v", timeout)
+		case <-ticker.C:
+			allowance, err := tonContract.Allowance(&bind.CallOpts{Context: timeoutCtx}, adminAddress, l2ManagerAddress)
+			if err != nil {
+				fmt.Printf("Error checking allowance: %v\n", err)
+				continue
+			}
+
+			if allowance.Cmp(requiredAmount) >= 0 {
+				fmt.Printf("✅ Allowance verified: %s TON\n", new(big.Float).Quo(new(big.Float).SetInt(allowance), big.NewFloat(1e18)).String())
+				return nil
+			}
+
+			fmt.Printf("Allowance: %s/%s (waiting...)\n", allowance.String(), requiredAmount.String())
+		}
+	}
 }
 
 // fromDeployContract flag would be true if the function would be called from the deploy contract function
@@ -259,6 +291,14 @@ func (t *ThanosStack) verifyRegisterCandidates(ctx context.Context, registerCand
 
 	fmt.Printf("Transaction confirmed in block %d\n", receiptApprove.BlockNumber.Uint64())
 
+	adminAddress, err := utils.GetAddressFromPrivateKey(t.deployConfig.AdminPrivateKey)
+	if err != nil {
+		return err
+	}
+
+	// Verify the allowance was set correctly
+	waitForAllowanceWithTimeout(ctx, tonContract, adminAddress, l2ManagerAddress, amountBigInt, 60*time.Second)
+
 	// Create contract instance
 	l2ManagerContract, err := abis.NewLayer2ManagerV1(l2ManagerAddress, l1Client)
 	if err != nil {
@@ -266,6 +306,17 @@ func (t *ThanosStack) verifyRegisterCandidates(ctx context.Context, registerCand
 	}
 
 	fmt.Println("Initiating transaction to register DAO candidate...")
+
+	// Final balance check before transfer
+	currentBalance, err := tonContract.BalanceOf(&bind.CallOpts{Context: ctx}, adminAddress)
+	if err != nil {
+		return fmt.Errorf("failed to get current balance: %v", err)
+	}
+
+	if currentBalance.Cmp(amountBigInt) < 0 {
+		return fmt.Errorf("insufficient balance at transfer time: have %s, required %s",
+			currentBalance.String(), amountBigInt.String())
+	}
 
 	// Call registerCandidateAddOn
 	txRegisterCandidate, err := l2ManagerContract.RegisterCandidateAddOn(


### PR DESCRIPTION
## Why did we need it?
In the candidate registration command we were getting an error - `TRANSFER_FROM_FAILED`.  Added an timer to check if allowance is confirmed.

## How Has This Been Tested?
This has been tested by using the standalone command to register candidate and command to deploy contracts and register candidate 

The tx hashes for both are - [standalone command](https://sepolia.etherscan.io/tx/0xf6eb6d397bbfda5ef81da272c58c21cc71175a6bed10013d3daf2123ae7b636a) and [deploy contract command](https://sepolia.etherscan.io/tx/0xaef67eb9734b9fff7e3889d53b34ce07e9e3ac2c0c23b03abed810705191c1c1)
