### PR TITLE
Fix: Candidate Registration Metadata Info 

### DIFF
--- a/pkg/stacks/thanos/register_metadata.go
+++ b/pkg/stacks/thanos/register_metadata.go
@@ -331,9 +331,8 @@ func (t *ThanosStack) RegisterMetadata(ctx context.Context) error {
 		}
 	}
 
-	parsedTime, _ := time.Parse("2006-01-02 15:04:05 MST", t.deployConfig.StakingInfo.RegistrationTime)
-
 	if t.deployConfig.StakingInfo != nil {
+		parsedTime, _ := time.Parse("2006-01-02 15:04:05 MST", t.deployConfig.StakingInfo.RegistrationTime)
 		metadata.Staking = types.Staking{
 			IsCandidate:           t.deployConfig.StakingInfo.IsCandidate,
 			CandidateRegisteredAt: parsedTime.UTC().Format(time.RFC3339),


### PR DESCRIPTION
This PR contains a fix to check and add candidate registration time when it's registered while updating metadata

## Why did we need it?

## Related Issue

## Release Note

## How Has This Been Tested?

## Screenshots (if appropriate):
