### PR TITLE
fix: update chain name validation to allow 14 characters or less

### DIFF
--- a/pkg/stacks/thanos/input.go
+++ b/pkg/stacks/thanos/input.go
@@ -24,8 +24,8 @@ import (
 )
 
 var (
-	// Chain name must be 10 characters or less, and can only contain letters, numbers, and spaces
-	chainNameRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9 ]{0,15}$`)
+	// Chain name must be 14 characters or less, and can only contain letters, numbers, and spaces
+	chainNameRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9 ]{0,13}$`)
 	// Pre-compiled regex patterns for validation
 	telegramTokenRegex = regexp.MustCompile(`^\d+:[A-Za-z0-9_-]+$`)
 	chatIdRegex        = regexp.MustCompile(`^-?\d+$`)
@@ -98,7 +98,7 @@ func (c *DeployInfraInput) Validate(ctx context.Context) error {
 	}
 
 	if !chainNameRegex.MatchString(c.ChainName) {
-		return errors.New("invalid chain name, chain name must contain only letters (a-z, A-Z), numbers (0-9), spaces with 15 characters or less. Special characters are not allowed")
+		return errors.New("invalid chain name, chain name must contain only letters (a-z, A-Z), numbers (0-9), spaces with 14 characters or less. Special characters are not allowed")
 	}
 
 	return nil
@@ -471,7 +471,7 @@ func InputDeployInfra() (*DeployInfraInput, error) {
 		}
 
 		if !chainNameRegex.MatchString(chainName) {
-			fmt.Println("Input must contain only letters (a-z, A-Z), numbers (0-9), spaces with 15 characters or less. Special characters are not allowed")
+			fmt.Println("Input must contain only letters (a-z, A-Z), numbers (0-9), spaces with 14 characters or less. Special characters are not allowed")
 			continue
 		}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -157,8 +157,8 @@ func ConvertChainNameToNamespace(chainName string) string {
 	processed = strings.ReplaceAll(processed, " ", "-")
 	processed = regexp.MustCompile(`[^a-z0-9-]`).ReplaceAllString(processed, "")
 	processed = strings.Trim(processed, "-")
-	if len(processed) > 20 {
-		processed = processed[:20]
+	if len(processed) > 14 {
+		processed = processed[:14]
 	}
 
 	// Generate random 5-character string with a-z and 0-9


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->

The character limit for receiving chain names has been adjusted from 20 characters to 14 characters.

- The maximum character limit for pods according to K8s policy is 63 characters (e.g., theosepolia082-8qfdv-1756355894-thanos-stack-op-proposer-7gtztw).
- StatefulSets automatically use a random 6-character suffix when deploying pods.
- If the pod name length limit is violated, the StatefulSet will generate an error during pod deployment, preventing the op-geth from being deployed properly.

Example resource name creation after configuration:
* Chain name: theosepolia082 (14 characters)
* Namespace: theosepolia082-abc12 (19 characters)
* Helm Release: theosepolia082-abc12-1755656728 (34 characters)
* Pod name: theosepolia082-abc12-1755656728-thanos-stack-op-proposer-7gtztw (64 characters)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
