### PR TITLE
Fix: PR naming scheme for update metadata

### DIFF
--- a/pkg/utils/git.go
+++ b/pkg/utils/git.go
@@ -306,8 +306,7 @@ func CheckExistingPRForBranch(username, token, repoName, branchName string) (*Gi
 	return nil, nil
 }
 
-func CheckPRStatus(pr *GitHubPR) (bool, bool) {
+func CheckPRStatus(pr *GitHubPR) bool {
 	isOpenPR := pr.State == "open"
-	isCreatePR := strings.Contains(pr.Title, "[Rollup]")
-	return isCreatePR, isOpenPR
+	return isOpenPR
 }


### PR DESCRIPTION
## Why did we need it?
This PR is needed to update the PR naming scheme as the checks fail, Issue is explained here - [Link](https://tokamak-network.slack.com/archives/C06UKCF86TE/p1758270931721069)

## Related Issue
Failing PR checks - [Link](https://github.com/tokamak-network/tokamak-rollup-metadata-repository/pull/48)

## How Has This Been Tested?
This has been tested by raising a new PR to update the metadata - [Link](https://github.com/tokamak-network/tokamak-rollup-metadata-repository/pull/50)
