### PR TITLE
Fix: backup manager incompatability issue for platform integration and bugs for getting the retention by aws API

### DIFF
--- a/commands/backup_manager.go
+++ b/commands/backup_manager.go
@@ -87,20 +87,23 @@ func ActionBackupManager() cli.ActionFunc {
 			return err
 
 		case flags.StartBackup:
-			return thanosStack.BackupSnapshot(ctx)
+			_, err := thanosStack.BackupSnapshot(ctx)
+			return err
 
 		case flags.ListPoints:
 			_, err := thanosStack.BackupList(ctx, flags.Limit)
 			return err
 
 		case flags.DoAttach:
-			return thanosStack.BackupAttach(ctx, &flags.AttachEfs, &flags.AttachPVCs, &flags.AttachSTSs)
+			_, err := thanosStack.BackupAttach(ctx, &flags.AttachEfs, &flags.AttachPVCs, &flags.AttachSTSs)
+			return err
 
 		case flags.DoRestore:
 			return handleRestore(ctx, thanosStack, flags)
 
 		case flags.DoConfigure:
-			return thanosStack.BackupConfigure(ctx, &flags.ConfigDaily, &flags.ConfigKeep, &flags.ConfigReset)
+			_, err := thanosStack.BackupConfigure(ctx, &flags.ConfigDaily, &flags.ConfigKeep, &flags.ConfigReset)
+			return err
 
 		default:
 			return errors.New("no action specified. Try --status, --snapshot, --list, --restore, --config, or --attach")

--- a/pkg/stacks/thanos/backup/attach.go
+++ b/pkg/stacks/thanos/backup/attach.go
@@ -213,12 +213,14 @@ func ExecuteBackupAttach(
 	}
 
 	l.Info("Creating recovery point for attached EFS...")
-	if err := SnapshotExecute(ctx, l, attachInfo.Region, attachInfo.Namespace); err != nil {
+	snapshotInfo, err := SnapshotExecute(ctx, l, attachInfo.Region, attachInfo.Namespace)
+	if err != nil {
 		l.Warnf("Failed to create recovery point: %v", err)
 		return nil
 	}
 
 	l.Info("✅ Recovery point created successfully")
+	l.Infof("   Job ID: %s", snapshotInfo.JobID)
 	return nil
 }
 

--- a/pkg/stacks/thanos/backup/list.go
+++ b/pkg/stacks/thanos/backup/list.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -17,7 +18,7 @@ func ListRecoveryPoints(ctx context.Context, region, arn, limit string) ([]types
 	if strings.TrimSpace(limit) == "" {
 		limit = "20"
 	}
-	jsonQuery := fmt.Sprintf("reverse(sort_by(RecoveryPoints,&CreationDate))[:%s].{Vault:BackupVaultName,Created:CreationDate,Expiry:ExpiryDate,Status:Status}", limit)
+	jsonQuery := fmt.Sprintf("reverse(sort_by(RecoveryPoints,&CreationDate))[:%s].{RecoveryPointARN:RecoveryPointArn,Vault:BackupVaultName,Created:CreationDate,Expiry:ExpiryDate,Status:Status}", limit)
 	out, err := utils.ExecuteCommand(ctx, "aws", "backup", "list-recovery-points-by-resource",
 		"--region", region,
 		"--resource-arn", arn,
@@ -38,91 +39,121 @@ func ListRecoveryPoints(ctx context.Context, region, arn, limit string) ([]types
 	return rps, nil
 }
 
-// DisplayRecoveryPoints renders recovery points with expiry calculation
+// DisplayRecoveryPoints renders recovery points in card style format
+// Only shows COMPLETED recovery points that can be used for restoration
 func DisplayRecoveryPoints(l *zap.SugaredLogger, rps []types.RecoveryPoint) {
-	if len(rps) == 0 {
-		l.Infof("   ⚠️  No recovery points found")
+	// Filter only COMPLETED recovery points
+	var completedRPs []types.RecoveryPoint
+	for _, rp := range rps {
+		if strings.ToUpper(rp.Status) == "COMPLETED" {
+			completedRPs = append(completedRPs, rp)
+		}
+	}
+
+	if len(completedRPs) == 0 {
+		l.Infof("")
+		l.Infof("⚠️  No available recovery points found")
+		l.Infof("")
 		return
 	}
 
-	// Calculate dynamic column widths based on actual data
-	maxVaultLen := 10   // minimum width for "Vault" header
-	maxCreatedLen := 10 // minimum width for "Created" header
-	maxExpiryLen := 10  // minimum width for "Expiry" header
-	maxStatusLen := 10  // minimum width for "Status" header
+	l.Infof("")
+	l.Infof("📦 Available Recovery Points (%d)", len(completedRPs))
+	l.Infof("")
 
-	// Find maximum lengths for each column
-	for _, rp := range rps {
-		if len(rp.Vault) > maxVaultLen {
-			maxVaultLen = len(rp.Vault)
+	for idx, rp := range completedRPs {
+		// Calculate relative times
+		createdRelative := formatRelativeTime(rp.Created)
+
+		// Display card
+		l.Infof("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		l.Infof("#%-2d", idx+1)
+		l.Infof("    🔑 ARN      : %s", rp.RecoveryPointARN)
+		l.Infof("    🗄️  Vault    : %s", rp.Vault)
+		l.Infof("    📅 Created  : %s %s", rp.Created, createdRelative)
+
+		// Handle expiry date - show "Never" if no expiry is set
+		if strings.TrimSpace(rp.Expiry) == "" {
+			l.Infof("    ⏰ Expires  : Never")
+		} else {
+			expiryRelative := formatRelativeTime(rp.Expiry)
+			l.Infof("    ⏰ Expires  : %s %s", rp.Expiry, expiryRelative)
 		}
-		if len(rp.Created) > maxCreatedLen {
-			maxCreatedLen = len(rp.Created)
-		}
-		if len(rp.Expiry) > maxExpiryLen {
-			maxExpiryLen = len(rp.Expiry)
-		}
-		if len(rp.Status) > maxStatusLen {
-			maxStatusLen = len(rp.Status)
+
+		l.Infof("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+
+		// Add spacing between cards (except for the last one)
+		if idx < len(completedRPs)-1 {
+			l.Infof("")
 		}
 	}
 
-	// Apply reasonable maximum limits to prevent extremely wide tables
-	const maxVaultWidth = 50
-	const maxCreatedWidth = 40
-	const maxExpiryWidth = 40
-	const maxStatusWidth = 15
+	l.Infof("")
+}
 
-	if maxVaultLen > maxVaultWidth {
-		maxVaultLen = maxVaultWidth
-	}
-	if maxCreatedLen > maxCreatedWidth {
-		maxCreatedLen = maxCreatedWidth
-	}
-	if maxExpiryLen > maxExpiryWidth {
-		maxExpiryLen = maxExpiryWidth
-	}
-	if maxStatusLen > maxStatusWidth {
-		maxStatusLen = maxStatusWidth
+// formatRelativeTime formats a timestamp to show relative time (e.g., "2 days ago")
+func formatRelativeTime(timestamp string) string {
+	if strings.TrimSpace(timestamp) == "" {
+		return ""
 	}
 
-	// Calculate total table width
-	totalWidth := maxVaultLen + maxCreatedLen + maxExpiryLen + maxStatusLen + 12 // 12 for spacing and borders
+	// Try parsing with different time formats
+	var t time.Time
+	var err error
 
-	l.Infof("   %s", strings.Repeat("-", totalWidth))
-	l.Infof("   |                EFS Recovery Points            |")
-	l.Infof("   %s", strings.Repeat("-", totalWidth))
+	// ISO8601 formats to try
+	formats := []string{
+		time.RFC3339,
+		"2006-01-02T15:04:05.000000-07:00",
+		"2006-01-02T15:04:05.000000Z07:00",
+		"2006-01-02T15:04:05Z07:00",
+		"2006-01-02T15:04:05.000Z",
+		"2006-01-02T15:04:05Z",
+	}
 
-	// Dynamic header formatting
-	headerFormat := fmt.Sprintf("   %%-%ds %%-%ds %%-%ds %%-%ds", maxVaultLen, maxCreatedLen, maxExpiryLen, maxStatusLen)
-	l.Infof(headerFormat, "Vault", "Created", "Expiry", "Status")
-	l.Infof("   %s", strings.Repeat("-", totalWidth))
-
-	// Dynamic row formatting
-	rowFormat := fmt.Sprintf("   %%-%ds %%-%ds %%-%ds %%-%ds", maxVaultLen, maxCreatedLen, maxExpiryLen, maxStatusLen)
-
-	for _, rp := range rps {
-		vault := rp.Vault
-		if len(vault) > maxVaultLen {
-			vault = vault[:maxVaultLen-3] + "..."
+	for _, format := range formats {
+		t, err = time.Parse(format, timestamp)
+		if err == nil {
+			break
 		}
-
-		created := rp.Created
-		if len(created) > maxCreatedLen {
-			created = created[:maxCreatedLen-3] + "..."
-		}
-
-		expiry := rp.Expiry
-		if len(expiry) > maxExpiryLen {
-			expiry = expiry[:maxExpiryLen-3] + "..."
-		}
-
-		status := rp.Status
-		if len(status) > maxStatusLen {
-			status = status[:maxStatusLen-3] + "..."
-		}
-
-		l.Infof(rowFormat, vault, created, expiry, status)
 	}
-	l.Infof("   %s", strings.Repeat("-", totalWidth))
+
+	if err != nil {
+		return ""
+	}
+
+	now := time.Now()
+	duration := now.Sub(t)
+
+	// If time is in the future
+	if duration < 0 {
+		duration = -duration
+		days := int(duration.Hours() / 24)
+		hours := int(duration.Hours()) % 24
+
+		if days > 0 {
+			return fmt.Sprintf("(in %d days)", days)
+		} else if hours > 0 {
+			return fmt.Sprintf("(in %d hours)", hours)
+		} else {
+			minutes := int(duration.Minutes())
+			return fmt.Sprintf("(in %d minutes)", minutes)
+		}
+	}
+
+	// If time is in the past
+	days := int(duration.Hours() / 24)
+	hours := int(duration.Hours()) % 24
+
+	if days > 0 {
+		return fmt.Sprintf("(%d days ago)", days)
+	} else if hours > 0 {
+		return fmt.Sprintf("(%d hours ago)", hours)
+	} else {
+		minutes := int(duration.Minutes())
+		if minutes <= 0 {
+			return "(just now)"
+		}
+		return fmt.Sprintf("(%d minutes ago)", minutes)
+	}
 }

--- a/pkg/stacks/thanos/backup/restore.go
+++ b/pkg/stacks/thanos/backup/restore.go
@@ -9,8 +9,184 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/tokamak-network/trh-sdk/pkg/types"
 	"github.com/tokamak-network/trh-sdk/pkg/utils"
 )
+
+// InteractiveRestoreWithSelection displays recovery points and lets user select one
+func InteractiveRestoreWithSelection(
+	ctx context.Context,
+	l *zap.SugaredLogger,
+	region, namespace string,
+	executeRestore func(context.Context, string) (*types.BackupRestoreInfo, error),
+) error {
+	// Get AWS account ID and EFS ID
+	accountID, err := utils.DetectAWSAccountID(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to detect AWS account ID: %w", err)
+	}
+
+	efsID, err := utils.DetectEFSId(ctx, namespace)
+	if err != nil || strings.TrimSpace(efsID) == "" {
+		return fmt.Errorf("failed to detect current EFS in namespace %s: %w", namespace, err)
+	}
+
+	resourceArn := utils.BuildEFSArn(region, accountID, efsID)
+
+	// List recovery points
+	rps, err := ListRecoveryPoints(ctx, region, resourceArn, "20")
+	if err != nil {
+		return fmt.Errorf("failed to list recovery points: %w", err)
+	}
+
+	// Filter only COMPLETED recovery points
+	var availablePoints []types.RecoveryPoint
+	for _, rp := range rps {
+		if strings.ToUpper(rp.Status) == "COMPLETED" {
+			availablePoints = append(availablePoints, rp)
+		}
+	}
+
+	if len(availablePoints) == 0 {
+		return fmt.Errorf("no available recovery points found for EFS %s", efsID)
+	}
+
+	// Display recovery points to user
+	l.Info("")
+	l.Infof("📦 Available Recovery Points (%d)", len(availablePoints))
+	l.Info("")
+
+	for i, rp := range availablePoints {
+		createdRelative := formatRelativeTime(rp.Created)
+
+		l.Infof("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		l.Infof("#%-2d", i+1) // Display 1-based index like --list
+		l.Infof("    🔑 ARN      : %s", rp.RecoveryPointARN)
+		l.Infof("    🗄️  Vault    : %s", rp.Vault)
+		l.Infof("    📅 Created  : %s %s", rp.Created, createdRelative)
+
+		if rp.Expiry != "" {
+			expiryRelative := formatRelativeTime(rp.Expiry)
+			l.Infof("    ⏰ Expires  : %s %s", rp.Expiry, expiryRelative)
+		} else {
+			l.Infof("    ⏰ Expires  : Never")
+		}
+
+		l.Infof("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		if i < len(availablePoints)-1 {
+			l.Info("")
+		}
+	}
+	l.Info("")
+
+	// Get user selection (1-based index)
+	var sel int
+	fmt.Printf("Enter index (1-%d): ", len(availablePoints))
+	if _, err := fmt.Scanf("%d", &sel); err != nil || sel < 1 || sel > len(availablePoints) {
+		return fmt.Errorf("invalid selection: must be between 1 and %d", len(availablePoints))
+	}
+
+	selectedArn := availablePoints[sel-1].RecoveryPointARN // Convert to 0-based array index
+
+	// Execute restore with selected ARN
+	_, err = executeRestore(ctx, selectedArn)
+	return err
+}
+
+// DirectRestore executes restore from a specific recovery point ARN without user interaction
+func DirectRestore(
+	ctx context.Context,
+	l *zap.SugaredLogger,
+	region, namespace string,
+	recoveryPointArn string,
+	restoreEFS func(context.Context, string) (string, error),
+	monitorRestore func(context.Context, string) (string, error),
+	handleCompletion func(context.Context, string) (string, error),
+	executeAttach func(context.Context, string, *string, *string, *string) error,
+) (*types.BackupRestoreInfo, error) {
+	// Validate ARN
+	if !strings.Contains(recoveryPointArn, "arn:aws:backup:") {
+		return nil, fmt.Errorf("invalid recovery point ARN: %s", recoveryPointArn)
+	}
+
+	l.Info("")
+	l.Infof("🔄 Starting restore from recovery point...")
+	l.Infof("    ARN: %s", recoveryPointArn)
+	l.Info("")
+
+	// Step 1: Start restore
+	jobID, err := restoreEFS(ctx, recoveryPointArn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start restore: %w", err)
+	}
+
+	l.Infof("📝 Restore job started: %s", jobID)
+	l.Info("")
+
+	// Step 2: Monitor restore
+	newEfsID, err := monitorRestore(ctx, jobID)
+	if err != nil {
+		return nil, fmt.Errorf("restore failed: %w", err)
+	}
+
+	l.Info("")
+	l.Infof("✅ Restore completed. New EFS: %s", newEfsID)
+
+	// Step 3: Tag EFS
+	if err := TagEFSWithName(ctx, region, newEfsID, namespace); err != nil {
+		l.Warnf("Failed to tag EFS %s with Name=%s: %v", newEfsID, namespace, err)
+	} else {
+		l.Infof("✅ Tagged EFS %s with Name=%s", newEfsID, namespace)
+	}
+
+	// Build restore info for API response
+	restoreInfo := &types.BackupRestoreInfo{
+		Region:           region,
+		Namespace:        namespace,
+		EFSID:            "", // Will be set by caller if needed
+		ARN:              "",
+		RecoveryPointARN: recoveryPointArn,
+		NewEFSID:         newEfsID,
+		JobID:            jobID,
+		Status:           "COMPLETED",
+	}
+
+	// Step 4: Ask user if they want to attach (only for CLI)
+	l.Info("")
+	var response string
+	fmt.Print("Would you like to attach the restored EFS to workloads now? (y/n) ")
+	if _, err := fmt.Scanf("%s", &response); err != nil {
+		l.Warnf("Failed to read input: %v", err)
+		response = "n"
+	}
+
+	response = strings.ToLower(strings.TrimSpace(response))
+	if response == "y" || response == "yes" {
+		l.Info("")
+		l.Info("🔗 Starting attach process...")
+
+		defaultPVCs := "op-geth,op-node"
+		defaultSTSs := "op-geth,op-node"
+
+		if err := executeAttach(ctx, newEfsID, &defaultPVCs, &defaultSTSs, nil); err != nil {
+			l.Errorf("❌ Attach failed: %v", err)
+			l.Info("You can manually attach later with:")
+			l.Infof("  ./trh-sdk backup-manager --attach --efs-id %s --pvc op-geth,op-node --sts op-geth,op-node", newEfsID)
+			restoreInfo.Status = "COMPLETED_WITH_ATTACH_ERROR"
+			return restoreInfo, err
+		}
+
+		l.Info("")
+		l.Info("✅ Attach completed successfully!")
+		restoreInfo.Status = "COMPLETED_WITH_ATTACH"
+	} else {
+		l.Info("")
+		l.Info("You can attach workloads to the restored EFS later with:")
+		l.Infof("  ./trh-sdk backup-manager --attach --efs-id %s --pvc op-geth,op-node --sts op-geth,op-node", newEfsID)
+	}
+
+	return restoreInfo, nil
+}
 
 // InteractiveRestore provides an interactive flow:
 // - Detect current EFS and list recent recovery points
@@ -36,7 +212,7 @@ func InteractiveRestore(
 	}
 	resourceArn := utils.BuildEFSArn(region, accountID, efsID)
 
-	query := "reverse(sort_by(RecoveryPoints,&CreationDate))[:20].{Arn:RecoveryPointArn,Created:CreationDate,Status:Status}"
+	query := "reverse(sort_by(RecoveryPoints,&CreationDate))[:20].{RecoveryPointArn:RecoveryPointArn,Created:CreationDate,Expiry:ExpiryDate,Status:Status,Vault:BackupVaultName}"
 	out, err := utils.ExecuteCommand(ctx, "aws", "backup", "list-recovery-points-by-resource",
 		"--region", region,
 		"--resource-arn", resourceArn,
@@ -50,32 +226,70 @@ func InteractiveRestore(
 	if out == "" || out == "[]" {
 		return fmt.Errorf("no recovery points found for %s", resourceArn)
 	}
-	var items []struct {
-		Arn     string `json:"Arn"`
-		Created string `json:"Created"`
-		Status  string `json:"Status"`
+	var allItems []struct {
+		RecoveryPointArn string `json:"RecoveryPointArn"`
+		Created          string `json:"Created"`
+		Expiry           string `json:"Expiry"`
+		Status           string `json:"Status"`
+		Vault            string `json:"Vault"`
 	}
-	if err := json.Unmarshal([]byte(out), &items); err != nil {
+	if err := json.Unmarshal([]byte(out), &allItems); err != nil {
 		return fmt.Errorf("failed to parse recovery points: %w", err)
 	}
 
-	l.Info("Select a recovery point to restore:")
+	// Filter only COMPLETED recovery points
+	var items []struct {
+		RecoveryPointArn string `json:"RecoveryPointArn"`
+		Created          string `json:"Created"`
+		Expiry           string `json:"Expiry"`
+		Status           string `json:"Status"`
+		Vault            string `json:"Vault"`
+	}
+	for _, item := range allItems {
+		if strings.ToUpper(item.Status) == "COMPLETED" {
+			items = append(items, item)
+		}
+	}
+
+	if len(items) == 0 {
+		return fmt.Errorf("no available recovery points found for %s", resourceArn)
+	}
+
+	l.Info("")
+	l.Infof("📦 Available Recovery Points (%d)", len(items))
 	l.Info("")
 
-	// Display recovery points in a more user-friendly format
+	// Display recovery points in card style format
 	for i, it := range items {
-		l.Infof("  [%d] Created: %s", i, it.Created)
-		l.Infof("      Status: %s", it.Status)
-		l.Infof("      ARN: %s", it.Arn)
-		l.Info("")
+		createdRelative := formatRelativeTimeRestore(it.Created)
+
+		l.Infof("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		l.Infof("[%d]", i)
+		l.Infof("    🔑 ARN      : %s", it.RecoveryPointArn)
+		l.Infof("    🗄️  Vault    : %s", it.Vault)
+		l.Infof("    📅 Created  : %s %s", it.Created, createdRelative)
+
+		// Handle expiry date - show "Never" if no expiry is set
+		if strings.TrimSpace(it.Expiry) == "" {
+			l.Infof("    ⏰ Expires  : Never")
+		} else {
+			expiryRelative := formatRelativeTimeRestore(it.Expiry)
+			l.Infof("    ⏰ Expires  : %s %s", it.Expiry, expiryRelative)
+		}
+
+		l.Infof("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		if i < len(items)-1 {
+			l.Info("")
+		}
 	}
+	l.Info("")
 
 	var sel int
 	fmt.Print("Enter index: ")
 	if _, err := fmt.Scanf("%d", &sel); err != nil || sel < 0 || sel >= len(items) {
 		return fmt.Errorf("invalid selection")
 	}
-	selectedArn := items[sel].Arn
+	selectedArn := items[sel].RecoveryPointArn
 
 	jobID, err := restoreEFS(ctx, selectedArn)
 	if err != nil {
@@ -365,4 +579,71 @@ func TagEFSWithName(ctx context.Context, region, fsId, name string) error {
 		"--tags", fmt.Sprintf("Key=Name,Value=%s", name),
 	)
 	return err
+}
+
+// formatRelativeTimeRestore formats a timestamp to show relative time (e.g., "2 days ago")
+func formatRelativeTimeRestore(timestamp string) string {
+	if strings.TrimSpace(timestamp) == "" {
+		return ""
+	}
+
+	// Try parsing with different time formats
+	var t time.Time
+	var err error
+
+	// ISO8601 formats to try
+	formats := []string{
+		time.RFC3339,
+		"2006-01-02T15:04:05.000000-07:00",
+		"2006-01-02T15:04:05.000000Z07:00",
+		"2006-01-02T15:04:05Z07:00",
+		"2006-01-02T15:04:05.000Z",
+		"2006-01-02T15:04:05Z",
+	}
+
+	for _, format := range formats {
+		t, err = time.Parse(format, timestamp)
+		if err == nil {
+			break
+		}
+	}
+
+	if err != nil {
+		return ""
+	}
+
+	now := time.Now()
+	duration := now.Sub(t)
+
+	// If time is in the future
+	if duration < 0 {
+		duration = -duration
+		days := int(duration.Hours() / 24)
+		hours := int(duration.Hours()) % 24
+
+		if days > 0 {
+			return fmt.Sprintf("(in %d days)", days)
+		} else if hours > 0 {
+			return fmt.Sprintf("(in %d hours)", hours)
+		} else {
+			minutes := int(duration.Minutes())
+			return fmt.Sprintf("(in %d minutes)", minutes)
+		}
+	}
+
+	// If time is in the past
+	days := int(duration.Hours() / 24)
+	hours := int(duration.Hours()) % 24
+
+	if days > 0 {
+		return fmt.Sprintf("(%d days ago)", days)
+	} else if hours > 0 {
+		return fmt.Sprintf("(%d hours ago)", hours)
+	} else {
+		minutes := int(duration.Minutes())
+		if minutes <= 0 {
+			return "(just now)"
+		}
+		return fmt.Sprintf("(%d minutes ago)", minutes)
+	}
 }

--- a/pkg/stacks/thanos/backup/snapshot.go
+++ b/pkg/stacks/thanos/backup/snapshot.go
@@ -7,20 +7,21 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/tokamak-network/trh-sdk/pkg/types"
 	"github.com/tokamak-network/trh-sdk/pkg/utils"
 )
 
-// SnapshotExecute triggers an on-demand EFS backup
-func SnapshotExecute(ctx context.Context, l *zap.SugaredLogger, region, namespace string) error {
+// SnapshotExecute triggers an on-demand EFS backup and returns snapshot information
+func SnapshotExecute(ctx context.Context, l *zap.SugaredLogger, region, namespace string) (*types.BackupSnapshotInfo, error) {
 	accountID, err := utils.DetectAWSAccountID(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	efsID, err := utils.DetectEFSId(ctx, namespace)
 	if err != nil || strings.TrimSpace(efsID) == "" {
 		l.Infof("📁 EFS: ❌ Not detected in cluster PVs: %v", err)
-		return nil
+		return nil, fmt.Errorf("failed to detect EFS: %w", err)
 	}
 
 	arn := utils.BuildEFSArn(region, accountID, efsID)
@@ -32,17 +33,28 @@ func SnapshotExecute(ctx context.Context, l *zap.SugaredLogger, region, namespac
 		"--backup-vault-name", backupVaultName,
 		"--resource-arn", arn,
 		"--iam-role-arn", iamRoleArn,
+		"--query", "BackupJobId",
+		"--output", "text",
 	)
 	if err != nil {
 		l.Errorf("📁 EFS: ❌ Failed to start backup job: %v", err)
 		l.Infof("   Backup vault: %s", backupVaultName)
 		l.Infof("   IAM role: %s", iamRoleArn)
-		return nil
+		return nil, fmt.Errorf("failed to start backup job: %w", err)
 	}
 
 	jobID := strings.TrimSpace(out)
 	l.Infof("📁 EFS: ✅ On-demand backup started successfully")
 	l.Infof("   Job ID: %s", jobID)
 	l.Infof("   Backup vault: %s", backupVaultName)
-	return nil
+
+	// Build and return snapshot info
+	return &types.BackupSnapshotInfo{
+		Region:    region,
+		Namespace: namespace,
+		EFSID:     efsID,
+		ARN:       arn,
+		JobID:     jobID,
+		Status:    "STARTED",
+	}, nil
 }

--- a/pkg/stacks/thanos/backup/status.go
+++ b/pkg/stacks/thanos/backup/status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -36,14 +37,16 @@ func GatherBackupStatusInfo(ctx context.Context, region, namespace string) (*typ
 	statusInfo.IsProtected = checkEFSProtectionStatus(ctx, region, statusInfo.ARN)
 	statusInfo.LatestRecoveryPoint = getLatestRecoveryPoint(ctx, region, statusInfo.ARN)
 
-	if statusInfo.LatestRecoveryPoint != "" && statusInfo.LatestRecoveryPoint != "None" {
-		// Only calculate expiry date if retention is not unlimited
-		if types.DefaultBackupRetentionDays > 0 {
-			statusInfo.ExpectedExpiryDate = calculateExpectedExpiryDate(statusInfo.LatestRecoveryPoint)
-		}
+	statusInfo.BackupVaults = getBackupVaults(ctx, region, statusInfo.ARN)
+
+	schedule, nextBackup, expiryDate, err := getBackupPlanInfo(ctx, region, namespace, statusInfo.LatestRecoveryPoint)
+	if err != nil {
+		return statusInfo, fmt.Errorf("failed to get backup plan info: %w", err)
 	}
 
-	statusInfo.BackupVaults = getBackupVaults(ctx, region, statusInfo.ARN)
+	statusInfo.BackupSchedule = schedule
+	statusInfo.NextBackupTime = nextBackup
+	statusInfo.ExpectedExpiryDate = expiryDate
 
 	return statusInfo, nil
 }
@@ -70,11 +73,11 @@ func DisplayBackupStatus(l *zap.SugaredLogger, statusInfo *types.BackupStatusInf
 		l.Warn("   Latest recovery point: ⚠️  None (no backups found)")
 	} else {
 		l.Infof("   Latest recovery point: ✅ %s", statusInfo.LatestRecoveryPoint)
-		if types.DefaultBackupRetentionDays == 0 {
-			l.Infof("   Expected expiry date: 📅 None (unlimited retention)")
-		} else if statusInfo.ExpectedExpiryDate != "" {
-			l.Infof("   Expected expiry date: 📅 %s (%d days from creation)", statusInfo.ExpectedExpiryDate, types.DefaultBackupRetentionDays)
-		}
+	}
+
+	// Handle expected expiry date display
+	if statusInfo.ExpectedExpiryDate != "" {
+		l.Infof("   Expected expiry date: 📅 %s", statusInfo.ExpectedExpiryDate)
 	}
 
 	// Handle backup vaults display
@@ -82,6 +85,14 @@ func DisplayBackupStatus(l *zap.SugaredLogger, statusInfo *types.BackupStatusInf
 		l.Warn("   Vaults: ⚠️  None (no backups found)")
 	} else {
 		l.Infof("   Vaults: ✅ %s", strings.Join(statusInfo.BackupVaults, ", "))
+	}
+
+	// Handle backup schedule display
+	if statusInfo.BackupSchedule != "" {
+		l.Infof("   Schedule: 📅 %s", statusInfo.BackupSchedule)
+		if statusInfo.NextBackupTime != "" {
+			l.Infof("   Next backup: ⏰ %s", statusInfo.NextBackupTime)
+		}
 	}
 
 	l.Info("")
@@ -110,23 +121,6 @@ func getLatestRecoveryPoint(ctx context.Context, region, arn string) string {
 	return strings.TrimSpace(rp)
 }
 
-func calculateExpectedExpiryDate(creationDate string) string {
-	// If retention is unlimited (0 days), return empty string
-	if types.DefaultBackupRetentionDays == 0 {
-		return ""
-	}
-
-	creationTime, err := time.Parse(types.TimeFormatISO8601, creationDate)
-	if err != nil {
-		creationTime, err = time.Parse(types.TimeFormatISO8601KST, creationDate)
-	}
-	if err != nil {
-		return ""
-	}
-	expiryTime := creationTime.AddDate(0, 0, types.DefaultBackupRetentionDays)
-	return expiryTime.Format(types.TimeFormatISO8601)
-}
-
 func getBackupVaults(ctx context.Context, region, arn string) []string {
 	vaultsJSON, err := utils.ExecuteCommand(ctx, "aws", "backup", "list-recovery-points-by-resource",
 		"--region", region,
@@ -153,4 +147,180 @@ func getBackupVaults(ctx context.Context, region, arn string) []string {
 		}
 	}
 	return unique
+}
+
+// getBackupPlanInfo retrieves comprehensive backup plan information from AWS Backup
+// Returns: (schedule, nextBackupTime, expiryDate, error)
+func getBackupPlanInfo(ctx context.Context, region, namespace, latestRecoveryPoint string) (string, string, string, error) {
+	// Try to find backup plans associated with the namespace
+	planName := fmt.Sprintf("%s-backup-plan", namespace)
+
+	// Step 1: List backup plans to find the namespace-specific plan
+	plansJSON, err := utils.ExecuteCommand(ctx, "aws", "backup", "list-backup-plans",
+		"--region", region,
+		"--query", fmt.Sprintf("BackupPlansList[?BackupPlanName=='%s']", planName),
+		"--output", "json")
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to list backup plans: %w", err)
+	}
+
+	plansJSON = strings.TrimSpace(plansJSON)
+	if plansJSON == "" || plansJSON == "null" || plansJSON == "[]" {
+		return "", "", "", fmt.Errorf("no backup plan found with name '%s'", planName)
+	}
+
+	// Step 2: Parse backup plan list to get plan ID
+	var plans []struct {
+		BackupPlanId   string `json:"BackupPlanId"`
+		BackupPlanName string `json:"BackupPlanName"`
+	}
+
+	if err := json.Unmarshal([]byte(plansJSON), &plans); err != nil {
+		return "", "", "", fmt.Errorf("failed to parse backup plans JSON: %w", err)
+	}
+
+	if len(plans) == 0 {
+		return "", "", "", fmt.Errorf("backup plan list is empty for '%s'", planName)
+	}
+
+	planId := plans[0].BackupPlanId
+
+	// Step 3: Get detailed backup plan information
+	planDetails, err := utils.ExecuteCommand(ctx, "aws", "backup", "get-backup-plan",
+		"--region", region,
+		"--backup-plan-id", planId,
+		"--output", "json")
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to get backup plan details (plan ID: %s): %w", planId, err)
+	}
+
+	// Step 4: Parse backup plan details to extract schedule and lifecycle information
+	var planInfo struct {
+		BackupPlan struct {
+			Rules []struct {
+				ScheduleExpression string `json:"ScheduleExpression"`
+				Lifecycle          *struct {
+					DeleteAfterDays int `json:"DeleteAfterDays"`
+				} `json:"Lifecycle"`
+			} `json:"Rules"`
+		} `json:"BackupPlan"`
+	}
+
+	if err := json.Unmarshal([]byte(planDetails), &planInfo); err != nil {
+		return "", "", "", fmt.Errorf("failed to parse backup plan details JSON: %w", err)
+	}
+
+	if len(planInfo.BackupPlan.Rules) == 0 {
+		return "", "", "", fmt.Errorf("backup plan '%s' has no rules configured", planName)
+	}
+
+	rule := planInfo.BackupPlan.Rules[0]
+
+	// Step 5: Extract and process information
+	// - Schedule: Convert cron expression to human-readable format
+	humanSchedule := parseCronToHuman(rule.ScheduleExpression)
+
+	// - Next Backup Time: Calculate next backup based on schedule
+	nextBackup := calculateNextBackupTime(rule.ScheduleExpression)
+
+	// - Expiry Date: Calculate based on lifecycle policy and latest recovery point
+	expiryDate := calculateExpiryDateFromPlan(rule.Lifecycle, latestRecoveryPoint)
+
+	return humanSchedule, nextBackup, expiryDate, nil
+}
+
+// parseCronToHuman converts AWS Backup cron expression to human-readable format
+// AWS Backup cron format: cron(minute hour day-of-month month day-of-week year)
+// Example: cron(0 3 * * ? *) = daily at 03:00 UTC
+func parseCronToHuman(cronExpr string) string {
+
+	if strings.HasPrefix(cronExpr, "cron(") && strings.HasSuffix(cronExpr, ")") {
+		// Remove cron() wrapper
+		cron := strings.TrimPrefix(strings.TrimSuffix(cronExpr, ")"), "cron(")
+		parts := strings.Fields(cron)
+
+		if len(parts) >= 2 {
+			minute := parts[0]
+			hour := parts[1]
+
+			// Convert to human-readable format
+			if minute == "0" {
+				return fmt.Sprintf("Daily at %s:00 UTC", hour)
+			} else {
+				return fmt.Sprintf("Daily at %s:%s UTC", hour, minute)
+			}
+		}
+	}
+
+	return "Custom schedule"
+}
+
+// calculateNextBackupTime calculates the next backup time based on cron expression
+// For simplicity, assumes daily backup and calculates next occurrence
+// Note: This is a basic implementation - for production, consider using a proper cron parser
+func calculateNextBackupTime(cronExpr string) string {
+
+	now := time.Now().UTC()
+	// Get today's date at 00:00:00 UTC
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+
+	// Extract hour and minute from cron expression
+	if strings.HasPrefix(cronExpr, "cron(") && strings.HasSuffix(cronExpr, ")") {
+		cron := strings.TrimPrefix(strings.TrimSuffix(cronExpr, ")"), "cron(")
+		parts := strings.Fields(cron)
+
+		if len(parts) >= 2 {
+			minute := parts[0]
+			hour := parts[1]
+
+			// Parse hour and minute
+			if h, err := strconv.Atoi(hour); err == nil {
+				if m, err := strconv.Atoi(minute); err == nil {
+					// Calculate today's backup time
+					nextBackup := time.Date(now.Year(), now.Month(), now.Day(), h, m, 0, 0, time.UTC)
+
+					// If the time has passed today, schedule for tomorrow
+					if nextBackup.Before(now) || nextBackup.Equal(now) {
+						nextBackup = nextBackup.AddDate(0, 0, 1)
+					}
+
+					return nextBackup.Format("2006-01-02 15:04 UTC")
+				}
+			}
+		}
+	}
+
+	// Fallback to next day at 03:00 UTC
+	tomorrow := today.AddDate(0, 0, 1)
+	return time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 3, 0, 0, 0, time.UTC).Format("2006-01-02 15:04 UTC")
+}
+
+// calculateExpiryDateFromPlan calculates expiry date based on backup plan lifecycle policy
+// Takes the lifecycle policy and latest recovery point creation date to calculate expiry
+func calculateExpiryDateFromPlan(lifecycle *struct {
+	DeleteAfterDays int `json:"DeleteAfterDays"`
+}, latestRecoveryPoint string) string {
+	// If no lifecycle policy or DeleteAfterDays is 0, retention is unlimited
+	if lifecycle == nil || lifecycle.DeleteAfterDays == 0 {
+		return "None (unlimited retention)"
+	}
+
+	// If no latest recovery point, cannot calculate expiry
+	if latestRecoveryPoint == "" || latestRecoveryPoint == "None" {
+		return "Unknown (no recovery points)"
+	}
+
+	// Parse the latest recovery point creation date
+	creationTime, err := time.Parse(types.TimeFormatISO8601, latestRecoveryPoint)
+	if err != nil {
+		// Try KST format as fallback
+		creationTime, err = time.Parse(types.TimeFormatISO8601KST, latestRecoveryPoint)
+	}
+	if err != nil {
+		return "Unknown (invalid date format)"
+	}
+
+	// Calculate expiry date by adding retention days
+	expiryTime := creationTime.AddDate(0, 0, lifecycle.DeleteAfterDays)
+	return fmt.Sprintf("%s (%d days from creation)", expiryTime.Format("2006-01-02 15:04 UTC"), lifecycle.DeleteAfterDays)
 }

--- a/pkg/stacks/thanos/backup/status.go
+++ b/pkg/stacks/thanos/backup/status.go
@@ -72,7 +72,7 @@ func DisplayBackupStatus(l *zap.SugaredLogger, statusInfo *types.BackupStatusInf
 	if statusInfo.LatestRecoveryPoint == "" || statusInfo.LatestRecoveryPoint == "None" {
 		l.Warn("   Latest recovery point: ⚠️  None (no backups found)")
 	} else {
-		l.Infof("   Latest recovery point: ✅ %s", statusInfo.LatestRecoveryPoint)
+		l.Infof("   Latest recovery point: %s", statusInfo.LatestRecoveryPoint)
 	}
 
 	// Handle expected expiry date display
@@ -84,7 +84,7 @@ func DisplayBackupStatus(l *zap.SugaredLogger, statusInfo *types.BackupStatusInf
 	if len(statusInfo.BackupVaults) == 0 {
 		l.Warn("   Vaults: ⚠️  None (no backups found)")
 	} else {
-		l.Infof("   Vaults: ✅ %s", strings.Join(statusInfo.BackupVaults, ", "))
+		l.Infof("   Vaults: %s", strings.Join(statusInfo.BackupVaults, ", "))
 	}
 
 	// Handle backup schedule display

--- a/pkg/stacks/thanos/backup_manager.go
+++ b/pkg/stacks/thanos/backup_manager.go
@@ -25,8 +25,8 @@ func (t *ThanosStack) BackupSnapshot(ctx context.Context) error {
 	return backup.SnapshotExecute(ctx, t.logger, t.deployConfig.AWS.Region, t.deployConfig.K8s.Namespace)
 }
 
-// BackupList lists recent EFS recovery points
-func (t *ThanosStack) BackupList(ctx context.Context, limit string) ([]types.RecoveryPoint, error) {
+// BackupList lists recent EFS recovery points and returns comprehensive information
+func (t *ThanosStack) BackupList(ctx context.Context, limit string) (*types.BackupListInfo, error) {
 	region := t.deployConfig.AWS.Region
 	namespace := t.deployConfig.K8s.Namespace
 
@@ -42,13 +42,26 @@ func (t *ThanosStack) BackupList(ctx context.Context, limit string) ([]types.Rec
 	}
 	arn := utils.BuildEFSArn(region, accountID, efsID)
 
+	if strings.TrimSpace(limit) == "" {
+		limit = "20"
+	}
+
 	rps, err := backup.ListRecoveryPoints(ctx, region, arn, strings.TrimSpace(limit))
 	if err != nil {
 		t.logger.Infof("   ❌ Error retrieving recovery points: %v", err)
 		return nil, err
 	}
 	backup.DisplayRecoveryPoints(t.logger, rps)
-	return rps, nil
+
+	// Return comprehensive backup list information
+	return &types.BackupListInfo{
+		Region:         region,
+		Namespace:      namespace,
+		EFSID:          efsID,
+		ResourceARN:    arn,
+		Limit:          limit,
+		RecoveryPoints: rps,
+	}, nil
 }
 
 // BackupRestore provides a fully interactive restore experience for EFS

--- a/pkg/stacks/thanos/backup_manager.go
+++ b/pkg/stacks/thanos/backup_manager.go
@@ -20,9 +20,13 @@ func (t *ThanosStack) BackupStatus(ctx context.Context) (*types.BackupStatusInfo
 	return statusInfo, nil
 }
 
-// BackupSnapshot triggers on-demand EFS backup
-func (t *ThanosStack) BackupSnapshot(ctx context.Context) error {
-	return backup.SnapshotExecute(ctx, t.logger, t.deployConfig.AWS.Region, t.deployConfig.K8s.Namespace)
+// BackupSnapshot triggers on-demand EFS backup and returns snapshot information
+func (t *ThanosStack) BackupSnapshot(ctx context.Context) (*types.BackupSnapshotInfo, error) {
+	snapshotInfo, err := backup.SnapshotExecute(ctx, t.logger, t.deployConfig.AWS.Region, t.deployConfig.K8s.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	return snapshotInfo, nil
 }
 
 // BackupList lists recent EFS recovery points and returns comprehensive information
@@ -100,7 +104,8 @@ func (t *ThanosStack) BackupRestore(ctx context.Context, recoveryPointArn string
 		},
 		func(c context.Context, efsId string, pvcs, stss, other *string) error {
 			// Use the same attach logic as BackupAttach
-			return t.BackupAttach(c, &efsId, pvcs, stss)
+			_, err := t.BackupAttach(c, &efsId, pvcs, stss)
+			return err
 		},
 	)
 
@@ -137,8 +142,8 @@ func (t *ThanosStack) BackupRestoreInteractive(ctx context.Context) error {
 	)
 }
 
-// BackupAttach switches workloads to use the new EFS and verifies readiness
-func (t *ThanosStack) BackupAttach(ctx context.Context, efsId *string, pvcs *string, stss *string) error {
+// BackupAttach switches workloads to use the new EFS and verifies readiness, returns attach information
+func (t *ThanosStack) BackupAttach(ctx context.Context, efsId *string, pvcs *string, stss *string) (*types.BackupAttachInfo, error) {
 	// gather info via backup subpackage
 	info, err := backup.GatherBackupAttachInfo(
 		ctx,
@@ -150,10 +155,10 @@ func (t *ThanosStack) BackupAttach(ctx context.Context, efsId *string, pvcs *str
 		func() { backup.ShowAttachUsage(t.logger) },
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	// execute via backup subpackage with injected helpers
-	return backup.ExecuteBackupAttach(
+	err = backup.ExecuteBackupAttach(
 		ctx,
 		t.logger,
 		info,
@@ -172,10 +177,17 @@ func (t *ThanosStack) BackupAttach(ctx context.Context, efsId *string, pvcs *str
 			})
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Update status after successful execution
+	info.Status = "attached"
+	return info, nil
 }
 
-// BackupConfigure applies EFS backup configuration via Terraform
-func (t *ThanosStack) BackupConfigure(ctx context.Context, daily *string, keep *string, reset *bool) error {
+// BackupConfigure applies EFS backup configuration via Terraform and returns configuration info
+func (t *ThanosStack) BackupConfigure(ctx context.Context, daily *string, keep *string, reset *bool) (*types.BackupConfigInfo, error) {
 	info, err := backup.GatherBackupConfigInfo(
 		t.deployConfig.AWS.Region,
 		t.deployConfig.K8s.Namespace,
@@ -183,7 +195,7 @@ func (t *ThanosStack) BackupConfigure(ctx context.Context, daily *string, keep *
 		func(format string, args ...any) { t.logger.Infof(format, args...) },
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	buildArgs := func(ci *types.BackupConfigInfo) []string {
 		return backup.BuildTerraformArgs(ci, func(format string, args ...any) { t.logger.Infof(format, args...) })
@@ -197,7 +209,14 @@ func (t *ThanosStack) BackupConfigure(ctx context.Context, daily *string, keep *
 			func(format string, a ...any) { t.logger.Warnf(format, a...) },
 		)
 	}
-	return backup.ExecuteBackupConfiguration(ctx, t.deploymentPath, info, buildArgs, execTf)
+	err = backup.ExecuteBackupConfiguration(ctx, t.deploymentPath, info, buildArgs, execTf)
+	if err != nil {
+		return nil, err
+	}
+
+	// Update status after successful execution
+	info.Status = "applied"
+	return info, nil
 }
 
 // CleanupUnusedBackupResources removes unused EFS filesystems and old recovery points during deploy

--- a/pkg/types/backup_manager.go
+++ b/pkg/types/backup_manager.go
@@ -18,6 +18,8 @@ type BackupStatusInfo struct {
 	LatestRecoveryPoint string
 	ExpectedExpiryDate  string
 	BackupVaults        []string
+	BackupSchedule      string
+	NextBackupTime      string
 }
 
 // BackupSnapshotInfo represents backup snapshot information

--- a/pkg/types/backup_manager.go
+++ b/pkg/types/backup_manager.go
@@ -37,17 +37,18 @@ type BackupListInfo struct {
 	Region         string
 	Namespace      string
 	EFSID          string
-	ARN            string
+	ResourceARN    string // EFS file system ARN
 	Limit          string
 	RecoveryPoints []RecoveryPoint
 }
 
 // RecoveryPoint represents a single recovery point
 type RecoveryPoint struct {
-	Vault   string
-	Created string
-	Expiry  string
-	Status  string
+	RecoveryPointARN string // Recovery point ARN for restoration
+	Vault            string
+	Created          string
+	Expiry           string
+	Status           string
 }
 
 // BackupRestoreInfo represents backup restore information


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

1. Refactor backup-manager to return structured info types (*Info) from all operations
2. Add `recovery-point-arn` parameter for direct restore mode, enabling platform integration compatibility and API automation support
3. Fix the bug for getting the retention of the status check

## Why did we need it?
<!--- Describe your changes in detail -->

The previous implementation returned only errors without operation metadata, making it impossible for the backend API to provide meaningful response data to clients and preventing automated restore workflows from using specific recovery points.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
