### PR TITLE
FIX: handles destroy retry when namespace already deleted

### DIFF
--- a/pkg/stacks/thanos/k8s.go
+++ b/pkg/stacks/thanos/k8s.go
@@ -26,9 +26,21 @@ func (t *ThanosStack) tryToDeleteK8sNamespace(ctx context.Context, namespace str
 		t.logger.Warn("Namespace is empty, skipping namespace deletion")
 		return nil
 	}
+
+	exists, err := utils.CheckNamespaceExists(ctx, namespace)
+	if err != nil {
+		t.logger.Error("Failed to check namespace existence", "namespace", namespace, "err", err)
+		return err
+	}
+	if !exists {
+		t.logger.Info("Namespace does not exist, skipping deletion")
+		return nil
+	}
+
 	output, err := utils.ExecuteCommand(ctx, "kubectl", "get", "namespace", namespace, "-o", "json")
 	if err != nil {
 		t.logger.Error("Error getting namespace status", "err", err)
+		return err
 	}
 
 	var status K8sNamespaceStatus


### PR DESCRIPTION
### Added a check to see if namespace exists before trying to delete it.


### When server crashes during destroy (after namespace deleted but before terraform runs), retry would fail at namespace deletion step. VPC, EFS and other AWS resources would remain orphaned with no way to clean them up.
                                                                                                                                                   
**How:**
  - Check namespace existence before deletion                                                                                                             
  - If already gone, skip and continue to terraform cleanup                                                                                               
  - Also fixed a bug where kubectl get error wasn't being returned    
  
  
**Testing**                                                                                                                                              
                                                                                                                                                          
Ran tests with minikube locally : destroy now works even when namespace is already deleted.

```
sahil@sye trh-sdk % go test -v ./pkg/stacks/thanos/...
=== RUN   TestTryToDeleteK8sNamespace
=== RUN   TestTryToDeleteK8sNamespace/empty_namespace
2025-12-27T20:01:40.793+0530    WARN    thanos/k8s.go:26        Namespace is empty, skipping namespace deletion
github.com/tokamak-network/trh-sdk/pkg/stacks/thanos.(*ThanosStack).tryToDeleteK8sNamespace
        /Users/sahil/work/current/trh-sdk/pkg/stacks/thanos/k8s.go:26
github.com/tokamak-network/trh-sdk/pkg/stacks/thanos.TestTryToDeleteK8sNamespace.func1
        /Users/sahil/work/current/trh-sdk/pkg/stacks/thanos/k8s_test.go:33
testing.tRunner
        /Users/sahil/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.11.darwin-arm64/src/testing/testing.go:1792
=== RUN   TestTryToDeleteK8sNamespace/non-existent_namespace
2025-12-27T20:01:40.834+0530    INFO    thanos/k8s.go:36        Namespace does not exist, skipping deletion
--- PASS: TestTryToDeleteK8sNamespace (0.22s)
    --- PASS: TestTryToDeleteK8sNamespace/empty_namespace (0.00s)
    --- PASS: TestTryToDeleteK8sNamespace/non-existent_namespace (0.04s)
=== RUN   TestCheckNamespaceExists
=== RUN   TestCheckNamespaceExists/missing_namespace
=== RUN   TestCheckNamespaceExists/existing_namespace
--- PASS: TestCheckNamespaceExists (0.11s)
    --- PASS: TestCheckNamespaceExists/missing_namespace (0.04s)
    --- PASS: TestCheckNamespaceExists/existing_namespace (0.04s)
PASS
ok      github.com/tokamak-network/trh-sdk/pkg/stacks/thanos    1.067s
?       github.com/tokamak-network/trh-sdk/pkg/stacks/thanos/backup     [no test files]
```